### PR TITLE
Fix null in QT GUI

### DIFF
--- a/qml/LauncherMain.qml
+++ b/qml/LauncherMain.qml
@@ -12,7 +12,7 @@ ColumnLayout {
     property VersionManager versionManager
     property ProfileManager profileManager
     property bool hasUpdate: false
-    property string updateDownloadUrl: null
+    property string updateDownloadUrl: ""
 
     id: rowLayout
     spacing: 0

--- a/qml/ThemedControls/PlayButton.qml
+++ b/qml/ThemedControls/PlayButton.qml
@@ -5,7 +5,7 @@ import QtQuick.Templates 2.1 as T
 T.Button {
     id: control
 
-    property string subText: null
+    property string subText: ""
 
     padding: 8
     implicitWidth: contentItem.implicitWidth + leftPadding + rightPadding
@@ -48,7 +48,7 @@ T.Button {
             }
             Text {
                 id: subTextItem
-                visible: control.subText != null && control.subText.length > 0
+                visible: control.subText.length > 0
                 text: control.subText
                 font.pointSize: 10
                 opacity: enabled ? 1.0 : 0.3


### PR DESCRIPTION
On recent QT Versions like 5.14 Qstring`s cannot be null anymore.
Currently QT converts it automatically to the Qstring "null", which will get displayed.