### PR TITLE
More detailed error messages

### DIFF
--- a/googleapkdownloadtask.cpp
+++ b/googleapkdownloadtask.cpp
@@ -20,6 +20,9 @@ void GoogleApkDownloadTask::start() {
     emit activeChanged();
     m_playApi->getApi()->delivery(m_packageName.toStdString(), m_versionCode, std::string())->call([this](playapi::proto::finsky::response::ResponseWrapper&& resp) {
         auto dd = resp.payload().deliveryresponse().appdeliverydata();
+        if((dd.has_gzippeddownloadurl() ? dd.gzippeddownloadurl() : dd.downloadurl()) == "") {
+            throw std::runtime_error("To use the download feature, Minecraft: Bedrock Edition has to be purchased on the Google Play Store.\nIf you are trying to download a beta version, please make sure you are in the Minecraft beta program on Google Play and then try again after a while (joining the program might take a while).");
+        }
         startDownload(dd);
     }, [this](std::exception_ptr e) {
         try {

--- a/qml/LauncherMain.qml
+++ b/qml/LauncherMain.qml
@@ -248,11 +248,19 @@ ColumnLayout {
         playApi: playApi
         packageName: "com.mojang.minecraftpe"
         onProgress: downloadProgress.value = progress
-        onError: console.log("Download failed: " + err)
+        onError: function(err) {
+            playDownloadError.text = err;
+            playDownloadError.open()
+        }
         onFinished: {
             apkExtractionTask.source = filePath
             apkExtractionTask.start()
         }
+    }
+
+    MessageDialog {
+        id: playDownloadError
+        title: "Download failed"
     }
 
     ApkExtractionTask {

--- a/qml/LauncherMain.qml
+++ b/qml/LauncherMain.qml
@@ -194,7 +194,7 @@ ColumnLayout {
 
             PlayButton {
                 Layout.alignment: Qt.AlignHCenter
-                text: (needsDownload() ? "Download and play" : "Play").toUpperCase()
+                text: (needsDownload() ? (googleLoginHelper.account !== null ? "Download and play" : "Sign in or import .apk") : "Play").toUpperCase()
                 subText: getDisplayedVersionName() ? ("Minecraft " + getDisplayedVersionName()).toUpperCase() : "Please wait..."
                 Layout.maximumWidth: 400
                 Layout.fillWidth: true
@@ -204,7 +204,7 @@ ColumnLayout {
                 onClicked: {
                     if (needsDownload()) {
                         if (googleLoginHelper.account === null) {
-                            showLaunchError("You must sign in to a Google account in order to download Minecraft.");
+                            launcherSettingsWindow.show();
                             return;
                         }
                         playDownloadTask.versionCode = getDownloadVersionCode()


### PR DESCRIPTION
Make some silent errors, only logged to console, easier to understand.
- Tell new players to buy the Game if they want to play, with an Google Account not owning the Game
- Tell players to join the Google Play Beta Program if download fails
- Redirect users without logged in Google Account to settings, to add other apks or finally sign in