### PR TITLE
Add some ui animations

### DIFF
--- a/qml.qrc
+++ b/qml.qrc
@@ -13,6 +13,7 @@
         <file>qml/ThemedControls/HorizontalDivider.qml</file>
         <file>qml/ThemedControls/MSideBarItem.qml</file>
         <file>qml/ThemedControls/CenteredScrollView.qml</file>
+        <file>qml/ThemedControls/AnimatedStackLayout.qml</file>
         <file>qml/MinecraftNews.qml</file>
         <file>qml/Launcher.qml</file>
         <file>qml/LauncherMain.qml</file>

--- a/qml/EditProfileWindow.qml
+++ b/qml/EditProfileWindow.qml
@@ -242,7 +242,7 @@ Window {
                 MButton {
                     text: "..."
                     enabled: dataDirCheck.checked
-                    height: dataDirPath.height
+                    Layout.preferredHeight: dataDirPath.height
                     onClicked: {
                         if (dataDirPath.text !== null && dataDirPath.text.length > 0)
                             dataDirPathDialog.folder = QmlUrlUtils.localFileToUrl(dataDirPath.text)

--- a/qml/LauncherBase.qml
+++ b/qml/LauncherBase.qml
@@ -114,13 +114,55 @@ ColumnLayout {
     }
 
     MProgressBar {
+        property bool showProgressbar: progressbarVisible || updateChecker.active
         Layout.fillWidth: true
         id: downloadProgress
         label: progressbarVisible ? progressbarText : qsTr("Please wait...")
         width: parent.width
-        height: 30
-        visible: progressbarVisible || updateChecker.active
+        visible: showProgressbar || closeAnim.running
         indeterminate: value < 0.005
+
+        states: State {
+            name: "visible"
+            when: downloadProgress.showProgressbar
+        }
+
+        transitions: [
+            Transition {
+                to: "visible"
+                NumberAnimation {
+                    target: downloadProgress
+                    property: "Layout.preferredHeight"
+                    to: 35
+                    duration: 200
+                    easing.type: Easing.OutCubic
+                }
+                NumberAnimation {
+                    target: downloadProgress
+                    property: "opacity"
+                    from: 0
+                    to: 1
+                    duration: 100
+                }
+            },
+            Transition {
+                id: closeAnim
+                to: "*"
+                NumberAnimation {
+                    target: downloadProgress
+                    property: "Layout.preferredHeight"
+                    to: 0
+                    duration: 200
+                    easing.type: Easing.OutCubic
+                }
+                NumberAnimation {
+                    target: downloadProgress
+                    property: "opacity"
+                    to: 0
+                    duration: 100
+                }
+            }
+        ]
     }
 
     MessageDialog {

--- a/qml/LauncherSettingsWindow.qml
+++ b/qml/LauncherSettingsWindow.qml
@@ -39,7 +39,7 @@ ColumnLayout {
         }
     }
 
-    StackLayout {
+    AnimatedStackLayout {
         id: settingsStackLayout
         currentIndex: tabs.currentIndex
         Layout.fillHeight: true

--- a/qml/MinecraftNews.qml
+++ b/qml/MinecraftNews.qml
@@ -80,22 +80,30 @@ ColumnLayout {
                     states: State {
                         name: "hovered"
                         when: mouseArea.hovered
-                        PropertyChanges {
-                            target: contentBox
-                            scale: 1.0 + (10 / contentBox.width)
-                        }
                     }
 
-                    transitions: Transition {
-                        to: "hovered"
-                        reversible: true
-                        PropertyAnimation {
-                            target: contentBox
-                            property: "scale"
-                            duration: 150
-                            easing.type: Easing.InOutCubic
+                    transitions: [
+                        Transition {
+                            to: "hovered"
+                            NumberAnimation {
+                                target: contentBox
+                                property: "scale"
+                                to: 1.0 + (12 / contentBox.width)
+                                duration: 180
+                                easing.type: Easing.OutCubic
+                            }
+                        },
+                        Transition {
+                            to: "*"
+                            NumberAnimation {
+                                target: contentBox
+                                property: "scale"
+                                to: 1.0
+                                duration: 100
+                                easing.type: Easing.OutSine
+                            }
                         }
-                    }
+                    ]
 
                     MouseArea {
                         id: mouseArea

--- a/qml/ThemedControls/AnimatedStackLayout.qml
+++ b/qml/ThemedControls/AnimatedStackLayout.qml
@@ -1,0 +1,66 @@
+import QtQuick
+import QtQuick.Layouts
+
+StackLayout {
+    id: root
+    property int previousIndex: 0
+    property Item previousItem: children[previousIndex]
+    property Item currentItem: children[currentIndex]
+
+    Component {
+        id: animator
+        ParallelAnimation {
+            property bool isGoingLeft
+            property int offset: isGoingLeft ? parent.width : -parent.width
+
+            NumberAnimation {
+                target: previousItem
+                property: "x"
+                from: 0
+                to: offset
+                duration: 200
+                easing.type: Easing.OutCubic
+            }
+            NumberAnimation {
+                target: previousItem
+                property: "opacity"
+                to: 0
+                duration: 150
+            }
+
+            NumberAnimation {
+                target: currentItem
+                property: "x"
+                from: -offset
+                to: 0
+                duration: 300
+                easing.type: Easing.OutCubic
+            }
+            NumberAnimation {
+                target: currentItem
+                property: "opacity"
+                to: 1
+                duration: 150
+            }
+
+            onStarted: previousItem.visible = true
+            onFinished: previousItem.visible = false
+        }
+    }
+
+    Component.onCompleted: previousIndex = currentIndex
+
+    onCurrentIndexChanged: {
+        previousItem = root.children[previousIndex]
+        currentItem = root.children[currentIndex]
+
+        if (previousItem && currentItem && (previousIndex !== currentIndex)) {
+            var anim = animator.createObject(parent, {
+                                                 "isGoingLeft": previousIndex > currentIndex
+                                             })
+            anim.restart()
+        }
+
+        previousIndex = currentIndex
+    }
+}

--- a/qml/ThemedControls/MComboBox.qml
+++ b/qml/ThemedControls/MComboBox.qml
@@ -73,6 +73,7 @@ T.ComboBox {
     }
 
     popup: T.Popup {
+        id: popupBox
         y: control.height
         width: control.width
         height: Math.min(contentItem.implicitHeight + topPadding + bottomPadding, control.Window.height - topMargin - bottomMargin)
@@ -93,6 +94,57 @@ T.ComboBox {
             color: "#1e1e1e"
             border.color: "#555"
             radius: 2
+        }
+
+        enter: Transition {
+            NumberAnimation {
+                property: "opacity"
+                from: 0
+                to: 1
+                duration: 100
+                easing.type: Easing.OutCubic
+            }
+
+            NumberAnimation {
+                property: "y"
+                from: 0
+                to: control.height
+                duration: 120
+                easing.type: Easing.OutCubic
+            }
+
+            NumberAnimation {
+                property: "scale"
+                from: 0.97
+                to: 1
+                duration: 80
+                easing.type: Easing.OutCubic
+            }
+        }
+
+        exit: Transition {
+            NumberAnimation {
+                property: "opacity"
+                from: 1
+                to: 0
+                duration: 80
+                easing.type: Easing.OutSine
+            }
+
+            NumberAnimation {
+                property: "y"
+                from: control.height
+                to: 0
+                duration: 80
+            }
+
+            NumberAnimation {
+                property: "scale"
+                from: 1
+                to: 0.97
+                duration: 60
+                easing.type: Easing.OutCubic
+            }
         }
     }
 }

--- a/qml/ThemedControls/MProgressBar.qml
+++ b/qml/ThemedControls/MProgressBar.qml
@@ -26,16 +26,23 @@ T.ProgressBar {
             Rectangle {
                 id: bar
                 color: "#008643"
-                x: -width
-                width: parent.width / 4
                 height: parent.height
-
                 NumberAnimation on x {
-                    from: -bar.width
-                    to: control.width + 60
+                    from: -control.width / 8
+                    to: control.width
                     loops: Animation.Infinite
                     running: control.indeterminate
-                    duration: 1400
+                    duration: 1200
+                    easing.type: Easing.InOutCubic
+                }
+
+                NumberAnimation on width {
+                    from: control.width / 10
+                    to: control.width / 2
+                    loops: Animation.Infinite
+                    running: control.indeterminate
+                    duration: 1200
+                    easing.type: Easing.InOutCubic
                 }
             }
         }

--- a/qml/ThemedControls/MSideBarItem.qml
+++ b/qml/ThemedControls/MSideBarItem.qml
@@ -11,12 +11,12 @@ T.Button {
     implicitWidth: implicitContentWidth
 
     background: Rectangle {
+        id: indicatorBar
         color: "#eee"
         width: 3
-        height: 20
+        height: 0
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        visible: control.checked
     }
 
     contentItem: RowLayout {
@@ -44,4 +44,32 @@ T.Button {
             Layout.rightMargin: 40
         }
     }
+
+    states: State {
+        name: "checked"
+        when: control.checked
+    }
+
+    transitions: [
+        Transition {
+            to: "checked"
+            NumberAnimation {
+                target: indicatorBar
+                property: "height"
+                to: 25
+                duration: 200
+                easing.type: Easing.OutCubic
+            }
+        },
+        Transition {
+            to: "*"
+            NumberAnimation {
+                target: indicatorBar
+                property: "height"
+                to: 0
+                duration: 180
+                easing.type: Easing.OutQuad
+            }
+        }
+    ]
 }

--- a/qml/ThemedControls/MTabButton.qml
+++ b/qml/ThemedControls/MTabButton.qml
@@ -9,12 +9,12 @@ T.TabButton {
     anchors.bottom: parent.bottom
 
     indicator: Rectangle {
+        id: indicatorBar
         color: "#9c6"
-        width: 30
+        width: 0
         height: 3
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
-        visible: checked
     }
 
     contentItem: Text {
@@ -26,4 +26,32 @@ T.TabButton {
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
     }
+
+    states: State {
+        name: "checked"
+        when: control.checked
+    }
+
+    transitions: [
+        Transition {
+            to: "checked"
+            NumberAnimation {
+                target: indicatorBar
+                property: "width"
+                to: 30
+                duration: 250
+                easing.type: Easing.OutCubic
+            }
+        },
+        Transition {
+            to: "*"
+            NumberAnimation {
+                target: indicatorBar
+                property: "width"
+                to: 0
+                duration: 180
+                easing.type: Easing.OutQuad
+            }
+        }
+    ]
 }

--- a/qml/ThemedControls/PlayButton.qml
+++ b/qml/ThemedControls/PlayButton.qml
@@ -21,6 +21,14 @@ T.Button {
         }
         horizontalTileMode: BorderImage.Stretch
         verticalTileMode: BorderImage.Stretch
+        Rectangle {
+            id: backgroundOverlay
+            anchors.centerIn: parent
+            width: parent.width - 2 * 8
+            height: parent.height - 2 * 8
+            color: "#1f1"
+            opacity: 0
+        }
     }
 
     contentItem: Item {
@@ -30,8 +38,7 @@ T.Button {
         ColumnLayout {
             id: content
             spacing: 0
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.centerIn: parent
             Text {
                 id: textItem
                 text: control.text
@@ -64,21 +71,41 @@ T.Button {
     states: State {
         name: "hovered"
         when: control.hovered && !control.down && control.enabled
-        PropertyChanges {
-            target: buttonBackground
-            scale: 1.05
-        }
     }
 
     transitions: [
         Transition {
             to: "hovered"
-            reversible: true
-            PropertyAnimation {
+            NumberAnimation {
                 target: buttonBackground
                 property: "scale"
+                to: 1.05
+                duration: 150
+                easing.type: Easing.OutCubic
+            }
+            NumberAnimation {
+                target: backgroundOverlay
+                property: "opacity"
+                to: 0.2
                 duration: 100
-                easing.type: Easing.InOutCubic
+                easing.type: Easing.OutCubic
+            }
+        },
+        Transition {
+            to: "*"
+            NumberAnimation {
+                target: buttonBackground
+                property: "scale"
+                to: 1
+                duration: 100
+                easing.type: Easing.OutQuad
+            }
+            NumberAnimation {
+                target: backgroundOverlay
+                property: "opacity"
+                to: 0
+                duration: 100
+                easing.type: Easing.OutCubic
             }
         }
     ]


### PR DESCRIPTION
**Please don't merge without testing on qt5**

* Update play button hover animation

https://github.com/minecraft-linux/mcpelauncher-ui-qt/assets/91605478/100bdef8-67b9-4394-a9e7-a2d30f773ace

* Slide in/out animation for downloadProgressbar, and update indeterminate animation

https://github.com/minecraft-linux/mcpelauncher-ui-qt/assets/91605478/0bee99ea-476b-4a57-9850-907dabb2aae5

* Slide in/out animation for combo box popup

https://github.com/minecraft-linux/mcpelauncher-ui-qt/assets/91605478/cdffe4e7-7dae-4efd-9bdf-cce4ec2477a0

* TabButton, SideBarItem indicator animation

https://github.com/minecraft-linux/mcpelauncher-ui-qt/assets/91605478/98582c40-e3a5-4120-881e-33ef90e46499

https://github.com/minecraft-linux/mcpelauncher-ui-qt/assets/91605478/c6efec44-23b3-4be7-be7d-238688cf2729

* StackLayout navigation animation

https://github.com/minecraft-linux/mcpelauncher-ui-qt/assets/91605478/1f9e50f2-59c3-4c74-b4b2-d4d9778e7922

**Other changes include:**

* Fix open data directory button size mismatch in profile edit window
* Update news content hover animation

I've tried to keep the animation duration within 60 - 250ms (time to reach 90% final state). But it might require some more tweaking. If you think some of these animations impact the user experience negatively, I can remove them.





