### PR TITLE
Make keyboard focus visible

### DIFF
--- a/qml.qrc
+++ b/qml.qrc
@@ -14,6 +14,7 @@
         <file>qml/ThemedControls/MSideBarItem.qml</file>
         <file>qml/ThemedControls/CenteredScrollView.qml</file>
         <file>qml/ThemedControls/AnimatedStackLayout.qml</file>
+        <file>qml/ThemedControls/FocusBorder.qml</file>
         <file>qml/MinecraftNews.qml</file>
         <file>qml/Launcher.qml</file>
         <file>qml/LauncherMain.qml</file>

--- a/qml/MinecraftNews.qml
+++ b/qml/MinecraftNews.qml
@@ -77,6 +77,10 @@ ColumnLayout {
                         }
                     }
 
+                    FocusBorder {
+                        visible: mouseArea.activeFocus
+                    }
+
                     states: State {
                         name: "hovered"
                         when: mouseArea.hovered
@@ -110,12 +114,19 @@ ColumnLayout {
                         property bool hovered: false
                         cursorShape: Qt.PointingHandCursor
                         anchors.fill: parent
-
                         hoverEnabled: true
+                        focus: true
+                        focusPolicy: "TabFocus"
+
                         onEntered: hovered = true
                         onExited: hovered = false
                         onClicked: {
                             hovered = false
+                            openArticle()
+                        }
+                        Keys.onSpacePressed: openArticle()
+
+                        function openArticle() {
                             Qt.openUrlExternally(modelData.url)
                         }
                     }

--- a/qml/ProfileComboBox.qml
+++ b/qml/ProfileComboBox.qml
@@ -73,7 +73,7 @@ MComboBox {
 
         background: Rectangle {
             anchors.fill: parent
-            color: (currentIndex == index) ? "#283" : (parent.hovered ? "#333" : "#1e1e1e")
+            color: highlighted ? "#283" : (parent.hovered ? "#333" : "#1e1e1e")
         }
     }
 

--- a/qml/ThemedControls/FocusBorder.qml
+++ b/qml/ThemedControls/FocusBorder.qml
@@ -1,0 +1,8 @@
+import QtQuick
+
+Rectangle {
+    anchors.fill: parent
+    color: "transparent"
+    border.width: 2
+    border.color: "#484"
+}

--- a/qml/ThemedControls/MButton.qml
+++ b/qml/ThemedControls/MButton.qml
@@ -13,6 +13,9 @@ T.Button {
         border.color: control.down ? "#888" : (control.hovered ? "#666" : "#555")
         color: control.down ? "#333" : "#1e1e1e"
         radius: 2
+        FocusBorder {
+            visible: control.visualFocus
+        }
     }
 
     contentItem: Text {

--- a/qml/ThemedControls/MCheckBox.qml
+++ b/qml/ThemedControls/MCheckBox.qml
@@ -53,4 +53,8 @@ T.CheckBox {
         verticalAlignment: Text.AlignVCenter
         leftPadding: implicitIndicatorWidth + 5
     }
+
+    background: FocusBorder {
+        visible: control.visualFocus
+    }
 }

--- a/qml/ThemedControls/MCheckBox.qml
+++ b/qml/ThemedControls/MCheckBox.qml
@@ -41,6 +41,10 @@ T.CheckBox {
                 context.stroke()
             }
         }
+
+        FocusBorder {
+            visible: control.visualFocus
+        }
     }
 
     contentItem: Text {
@@ -52,9 +56,5 @@ T.CheckBox {
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
         leftPadding: implicitIndicatorWidth + 5
-    }
-
-    background: FocusBorder {
-        visible: control.visualFocus
     }
 }

--- a/qml/ThemedControls/MComboBox.qml
+++ b/qml/ThemedControls/MComboBox.qml
@@ -30,7 +30,7 @@ T.ComboBox {
     }
 
     delegate: ItemDelegate {
-        width: control.width
+        width: parent.width
         contentItem: Text {
             text: modelData
             color: "#fff"
@@ -43,6 +43,10 @@ T.ComboBox {
             anchors.fill: parent
             color: parent.hovered ? "#333" : "#1e1e1e"
             radius: 2
+
+            FocusBorder {
+                visible: highlighted
+            }
         }
     }
 

--- a/qml/ThemedControls/MComboBox.qml
+++ b/qml/ThemedControls/MComboBox.qml
@@ -14,6 +14,9 @@ T.ComboBox {
     background: Rectangle {
         border.color: control.hovered ? "#666" : "#555"
         color: "#1e1e1e"
+        FocusBorder {
+            visible: control.visualFocus
+        }
     }
 
     contentItem: Text {

--- a/qml/ThemedControls/MSideBarItem.qml
+++ b/qml/ThemedControls/MSideBarItem.qml
@@ -10,13 +10,18 @@ T.Button {
     implicitHeight: 50
     implicitWidth: implicitContentWidth
 
-    background: Rectangle {
-        id: indicatorBar
-        color: "#eee"
-        width: 3
-        height: 0
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
+    background: Item {
+        Rectangle {
+            id: indicatorBar
+            color: "#eee"
+            width: 3
+            height: 0
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+        }
+        FocusBorder {
+            visible: control.visualFocus
+        }
     }
 
     contentItem: RowLayout {

--- a/qml/ThemedControls/MTabButton.qml
+++ b/qml/ThemedControls/MTabButton.qml
@@ -17,6 +17,10 @@ T.TabButton {
         anchors.bottom: parent.bottom
     }
 
+    background: FocusBorder {
+        visible: control.visualFocus
+    }
+
     contentItem: Text {
         text: control.text
         font.pointSize: 11

--- a/qml/ThemedControls/MTextField.qml
+++ b/qml/ThemedControls/MTextField.qml
@@ -18,5 +18,9 @@ T.TextField {
         border.color: control.hovered ? "#666" : "#555"
         color: "#1e1e1e"
         radius: 2
+
+        FocusBorder {
+            visible: control.focus
+        }
     }
 }

--- a/qml/ThemedControls/PlayButton.qml
+++ b/qml/ThemedControls/PlayButton.qml
@@ -29,6 +29,9 @@ T.Button {
             color: "#1f1"
             opacity: 0
         }
+        FocusBorder {
+            visible: control.visualFocus
+        }
     }
 
     contentItem: Item {

--- a/qml/ThemedControls/TransparentButton.qml
+++ b/qml/ThemedControls/TransparentButton.qml
@@ -15,6 +15,9 @@ T.Button {
         id: buttonBackground
         color: "#08FFFFFF"
         visible: control.hovered && !control.down
+        FocusBorder {
+            visible: control.visualFocus
+        }
     }
 
     contentItem: Text {


### PR DESCRIPTION
Not the most efficient approach, but good enough to get a uniform look.

Some contents don't have proper border layout, but I don't think it needs fixing. 
![screenshot-24-04-21-10-56](https://github.com/minecraft-linux/mcpelauncher-ui-qt/assets/91605478/18acb4b1-2de4-4ad8-a6b9-a76420859800)
