### PR TITLE
Allow pressing Enter to submit the unlock password

### DIFF
--- a/qml/UnlockScreen.qml
+++ b/qml/UnlockScreen.qml
@@ -9,6 +9,9 @@ BaseScreen {
 
     signal finished
 
+    Keys.onReturnPressed: attemptUnlock()
+    Keys.onEnterPressed: attemptUnlock()
+
     headerContent: TabBar {
         background: null
         MTabButton {
@@ -33,7 +36,6 @@ BaseScreen {
             id: continueInvalidCredentials
             Layout.topMargin: 10
             text: qsTr("Continue with invalid credentials")
-            focus: true
         }
 
         Item {
@@ -77,6 +79,7 @@ BaseScreen {
             Layout.fillWidth: true
             echoMode: TextInput.Password
             enabled: !continueInvalidCredentials.checked
+            focus: true
             onAccepted: attemptUnlock()
             onTextChanged: {
                 pwd.color = "#fff"


### PR DESCRIPTION
## Summary
- Move initial keyboard focus from the "Continue with invalid credentials" checkbox to the password text field, so the user can start typing immediately
- Add `Keys.onReturnPressed` and `Keys.onEnterPressed` handlers at the screen level so pressing Enter triggers submission regardless of which control has focus
- The existing `onAccepted` handler on the text field only fires when the field itself is focused; the screen-level key handlers ensure Enter always works

Fixes minecraft-linux/mcpelauncher-ui-qt#45

## Test plan
- [ ] Open the unlock password dialog
- [ ] Verify the password field has focus automatically (cursor blinking in the field)
- [ ] Type a password and press Enter -- should submit
- [ ] Check the "Continue with invalid credentials" checkbox and press Enter -- should submit
- [ ] Click the "Continue" button -- should still work as before