### PR TITLE
Fix Google login save-password crash and DRM update applicability on equal version code

### DIFF
--- a/googleloginhelper.cpp
+++ b/googleloginhelper.cpp
@@ -95,9 +95,31 @@ void GoogleLoginHelper::acquireAccount(QWindow *parent) {
 }
 
 void GoogleLoginHelper::onLoginFinished(int code) {
+    // Detach the dialog pointer early to avoid re-entrant UI transitions
+    // from QML handlers while the dialog teardown is still in progress.
+    auto* finishedWindow = window;
+    window = nullptr;
+
+    auto emitFinish = [this](GoogleAccount* account) {
+        QMetaObject::invokeMethod(this, [this, account]() {
+            emit accountAcquireFinished(account);
+            emit accountInfoChanged();
+        }, Qt::QueuedConnection);
+    };
+
+    if (!finishedWindow) {
+        emitFinish(nullptr);
+        return;
+    }
+
     if (code == QDialog::Accepted) {
         try {
-            unlockkey = window->encryptionToken();
+            const QString encryptionToken = finishedWindow->encryptionToken();
+            const QString accountToken = finishedWindow->accountToken();
+            const QString accountIdentifier = finishedWindow->accountIdentifier();
+            const QString accountUserId = finishedWindow->accountUserId();
+
+            unlockkey = encryptionToken;
             Encryption enc;
             if(unlockkey.isEmpty()) {
                 unlockkey = QString::fromStdString(enc.RandomKey());
@@ -105,9 +127,9 @@ void GoogleLoginHelper::onLoginFinished(int code) {
             }
             loginCache.clear();
             loginCache.setKey(unlockkey.toStdString());
-            login.perform_with_access_token(window->accountToken().toStdString(), window->accountIdentifier().toStdString(), true)->call();
+            login.perform_with_access_token(accountToken.toStdString(), accountIdentifier.toStdString(), true)->call();
             currentAccount.setAccountIdentifier(QString::fromStdString(login.get_email()));
-            currentAccount.setAccountUserId(window->accountUserId());
+            currentAccount.setAccountUserId(accountUserId);
             currentAccount.setAccountToken(QString::fromStdString(login.get_token()));
             hasAccount = currentAccount.isValid();
             if (hasAccount) {
@@ -118,20 +140,18 @@ void GoogleLoginHelper::onLoginFinished(int code) {
                 settings.setValue("token", QString::fromStdString(enc.Encrypt(currentAccount.accountToken().toStdString(), unlockkey.toStdString())));
                 settings.endGroup();
                 saveDeviceState();
-                accountAcquireFinished(&currentAccount);
+                emitFinish(&currentAccount);
             } else {
                 loginError("Login failed");
-                accountAcquireFinished(nullptr);
+                emitFinish(nullptr);
             }
         } catch (const std::exception& ex) {
             loginError(ex.what());
-            accountAcquireFinished(nullptr);
+            emitFinish(nullptr);
         }
     } else {
-        accountAcquireFinished(nullptr);
+        emitFinish(nullptr);
     }
-    emit accountInfoChanged();
-    window = nullptr;
 }
 
 void GoogleLoginHelper::updateDevice() {

--- a/updatemanager.cpp
+++ b/updatemanager.cpp
@@ -48,7 +48,9 @@ UpdateManager::UpdateManager(QObject *parent)
                 bool isApplicable = false;
                 for(auto et = extraVersions.rbegin(); et != extraVersions.rend(); ++et) {
                     auto codes = et->toMap().value("codes").toMap();
-                    if(codes.contains(maxKnownVersionAbi) && codes[maxKnownVersionAbi].toInt() > maxKnownVersion) {
+                    // Keep showing DRM/runtime updates when the launcher DB knows the same
+                    // version code, because those builds can still require update mods.
+                    if(codes.contains(maxKnownVersionAbi) && codes[maxKnownVersionAbi].toInt() >= maxKnownVersion) {
                         isApplicable = true;
                         break;
                     }   


### PR DESCRIPTION
## Summary

This PR contains two focused fixes discovered while bringing Bedrock `1.26.0.2` up on Linux:

1. `googleloginhelper.cpp`
- Avoids a crash during Google login completion when saving encryption password by:
  - detaching `window` early,
  - capturing dialog values before teardown,
  - emitting completion/account-change signals via queued invocation to avoid re-entrant QML teardown.

2. `updatemanager.cpp`
- Changes DRM update applicability check from `>` to `>=` for `extraVersions` code matching the known launcher version code.
- This keeps update-mod prompts available when version DB already knows the same version code but runtime DRM patching is still required.

## Repro / Motivation

- Google login flow crashed exactly at password-save confirmation (`SIGSEGV`) before account persisted.
- For newer Google Play Bedrock builds requiring `mcpelauncher-updates`, launcher did not always offer update banner when `extraVersions` code == max known version code.

## Scope

- No API changes.
- Two file changes only:
  - `googleloginhelper.cpp`
  - `updatemanager.cpp`
